### PR TITLE
resolve #1296 Remove of ZMQ_IDENTITY_FD socket option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -326,7 +326,6 @@ test_apps = \
 	test_connect_rid \
 	test_bind_src_address \
 	test_metadata \
-	test_id2fd \
 	test_capabilities \
 	test_xpub_nodrop
 

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -676,23 +676,6 @@ Option value unit:: N/A
 Default value:: not set
 Applicable socket types:: all, when using TCP transport
 
-ZMQ_IDENTITY_FD: Retrieve FD associated with igven identity
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The 'ZMQ_IDENTITY_FD' option shall retrieve the FD associated with given identity. 
-call _zmq_getsockopt()_ with _option_value_ / _option_len_ pointing to memory 
-holding the identity string. On return the start of _option_value_ buffer will be 
-filled with file descriptor of the pipe with given identity if found. If the identity 
-is not found ENOTSOCK is returned as _zmq_getsockopt()_  result. When the pipe is not 
-using FD as lower transport you might get -1 as FD. NB: _option_value_ must be always 
-big  enough to hold sizeof(fd_t) bytes no matter how small the identity length is.
-
-[horizontal]
-Option value type:: character string/fd_t
-Option value unit:: N/A
-Default value:: not set
-Applicable socket types:: ROUTER
-
 
 RETURN VALUE
 ------------

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -301,7 +301,6 @@ ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
 #define ZMQ_GSSAPI_SERVICE_PRINCIPAL 64
 #define ZMQ_GSSAPI_PLAINTEXT 65
 #define ZMQ_HANDSHAKE_IVL 66
-#define ZMQ_IDENTITY_FD 67
 #define ZMQ_SOCKS_PROXY 68
 #define ZMQ_XPUB_NODROP 69
 

--- a/src/i_engine.hpp
+++ b/src/i_engine.hpp
@@ -20,8 +20,6 @@
 #ifndef __ZMQ_I_ENGINE_HPP_INCLUDED__
 #define __ZMQ_I_ENGINE_HPP_INCLUDED__
 
-#include "fd.hpp"
-
 namespace zmq
 {
 
@@ -49,10 +47,7 @@ namespace zmq
         //  are messages to send available.
         virtual void restart_output () = 0;
 
-        virtual void zap_msg_available () = 0; 
-        
-        // provide a way to link from engine to file descriptor 
-        virtual fd_t get_assoc_fd () { return retired_fd;};
+        virtual void zap_msg_available () = 0;
     };
 
 }

--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -65,7 +65,6 @@ int zmq::pipepair (class object_t *parents_ [2], class pipe_t* pipes_ [2],
 zmq::pipe_t::pipe_t (object_t *parent_, upipe_t *inpipe_, upipe_t *outpipe_,
       int inhwm_, int outhwm_, bool conflate_) :
     object_t (parent_),
-    assoc_fd (retired_fd),
     inpipe (inpipe_),
     outpipe (outpipe_),
     in_active (true),

--- a/src/pipe.hpp
+++ b/src/pipe.hpp
@@ -27,7 +27,6 @@
 #include "stdint.hpp"
 #include "array.hpp"
 #include "blob.hpp"
-#include "fd.hpp"
 
 namespace zmq
 {
@@ -120,8 +119,6 @@ namespace zmq
 
         // check HWM
         bool check_hwm () const;
-        // provide a way to link pipe to engine fd. Set on session initialization
-        fd_t assoc_fd; //=retired_fd
     private:
 
         //  Type of the underlying lock-free pipe.

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -133,33 +133,6 @@ int zmq::router_t::xsetsockopt (int option_, const void *optval_,
     return -1;
 }
 
-int zmq::router_t::xgetsockopt (int option_, const void *optval_,
-    size_t *optvallen_)
-{
-    switch (option_) {
-        case ZMQ_IDENTITY_FD:
-            if (optval_==NULL && optvallen_) {
-                *optvallen_=sizeof(fd_t);
-                return 0;
-            }
-            if (optval_ && optvallen_ && *optvallen_) {
-                blob_t identity= blob_t((unsigned char*)optval_,*optvallen_);
-                outpipes_t::iterator it = outpipes.find (identity);
-                if (it == outpipes.end() ){
-                    return ENOTSOCK;
-                }
-                *((fd_t*)optval_)=it->second.pipe->assoc_fd;
-                *optvallen_=sizeof(fd_t);
-                return 0;
-            }
-            break;
-        default:
-            break;
-    }
-    errno = EINVAL;
-    return -1;
-}
-
 
 void zmq::router_t::xpipe_terminated (pipe_t *pipe_)
 {

--- a/src/router.hpp
+++ b/src/router.hpp
@@ -47,7 +47,6 @@ namespace zmq
         //  Overrides of functions from socket_base_t.
         void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
         int xsetsockopt (int option_, const void *optval_, size_t optvallen_);
-        int xgetsockopt (int option_, const void *optval_, size_t *optvallen_);
         int xsend (zmq::msg_t *msg_);
         int xrecv (zmq::msg_t *msg_);
         bool xhas_in ();

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -367,9 +367,7 @@ void zmq::session_base_t::process_attach (i_engine *engine_)
         //  Remember the local end of the pipe.
         zmq_assert (!pipe);
         pipe = pipes [0];
-        // Store engine assoc_fd for linking pipe to fd
-        pipe->assoc_fd = engine_->get_assoc_fd ();
-        pipes [1]->assoc_fd = pipe->assoc_fd;
+
         //  Ask socket to plug into the remote end of the pipe.
         send_bind (socket, pipes [1]);
     }

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -288,11 +288,6 @@ int zmq::socket_base_t::getsockopt (int option_, void *optval_,
         errno = ETERM;
         return -1;
     }
-    
-    //  First, check whether specific socket type overloads the option.
-    int rc = xgetsockopt (option_, optval_, optvallen_);
-    if (rc == 0 || errno != EINVAL)
-        return rc;
 
     if (option_ == ZMQ_RCVMORE) {
         if (*optvallen_ < sizeof (int)) {
@@ -1062,11 +1057,6 @@ void zmq::socket_base_t::process_destroy ()
 }
 
 int zmq::socket_base_t::xsetsockopt (int, const void *, size_t)
-{
-    errno = EINVAL;
-    return -1;
-}
-int zmq::socket_base_t::xgetsockopt (int, const void *, size_t*)
 {
     errno = EINVAL;
     return -1;

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -133,12 +133,9 @@ namespace zmq
 
         //  The default implementation assumes there are no specific socket
         //  options for the particular socket type. If not so, override this
-        //  methods.
+        //  method.
         virtual int xsetsockopt (int option_, const void *optval_,
             size_t optvallen_);
-
-        virtual int xgetsockopt (int option_, const void *optval_,
-            size_t *optvallen_);
 
         //  The default implementation assumes that send is not supported.
         virtual bool xhas_out ();

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -76,8 +76,6 @@ namespace zmq
         void out_event ();
         void timer_event (int id_);
 
-        // export s via i_engine so it is possible to link a pipe to fd
-        fd_t get_assoc_fd (){ return s; };
     private:
 
         //  Unplug the engine from the session.


### PR DESCRIPTION
Revert "linking fd to pipe identity via socket option"

This reverts commit fe3e8c5c70dc3fbcb0244c5f4c52dcd71b80f858.

Conflicts:
	include/zmq.h
	src/pipe.hpp
	src/session_base.cpp