### PR TITLE
Problem: event interface isn't compatible with CZMQ 3.0

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -71,18 +71,9 @@ extern "C" {
 #endif
 
 /*  Define integer types needed for event interface                          */
+#define ZMQ_DEFINED_STDINT 1
 #if defined ZMQ_HAVE_SOLARIS || defined ZMQ_HAVE_OPENVMS
 #   include <inttypes.h>
-#elif defined _MSC_VER && _MSC_VER < 1600
-#   ifndef int32_t
-typedef __int32 int32_t;
-#   endif
-#   ifndef uint16_t
-typedef unsigned __int16 uint16_t;
-#   endif
-#   ifndef uint8_t
-typedef unsigned __int8 uint8_t;
-#   endif
 #else
 #   include <stdint.h>
 #endif


### PR DESCRIPTION
Solution: backport the latest STDINT definitions from libzmq.

Fixes #34