### PR TITLE
Problem: 4.1 broke the ABI yet did not bump ABI number

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,9 +31,10 @@ AC_SUBST(PACKAGE_VERSION)
 # ZeroMQ version 3.0: 2:0:0 (ABI version 2)
 # ZeroMQ version 3.1: 3:0:0 (ABI version 3)
 # ZeroMQ version 4.0: 4:0:0 (ABI version 4)
+# ZeroMQ version 4.1: 5:0:0 (ABI version 5)
 #
 # libzmq -version-info current:revision:age
-LTVER="4:0:0"
+LTVER="5:0:0"
 AC_SUBST(LTVER)
 
 # Take a copy of original flags


### PR DESCRIPTION
Solution: bump to ABI version 5