### PR TITLE
Solution: check for libtoolize in autogen. Fixes #54

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -20,10 +20,14 @@
 
 # Script to generate all required files from fresh git checkout.
 
-command -v libtool >/dev/null 2>&1
+# Debian and Ubuntu do not shipt libtool anymore, but OSX does not ship libtoolize.
+command -v libtoolize >/dev/null 2>&1
 if  [ $? -ne 0 ]; then
-    echo "autogen.sh: error: could not find libtool.  libtool is required to run autogen.sh." 1>&2
-    exit 1
+    command -v libtool >/dev/null 2>&1
+    if  [ $? -ne 0 ]; then
+        echo "autogen.sh: error: could not find libtool.  libtool is required to run autogen.sh." 1>&2
+        exit 1
+    fi
 fi
 
 command -v autoreconf >/dev/null 2>&1


### PR DESCRIPTION
Autogen.sh looks for the libtool command as a mean to check if
libtool is available. But distributions like Debian and Ubuntu have
split the libtool package, and the libtool script is now in a
separate package. The solution is to look for the libtoolize command
too before failing, which is what the Autotools chain actually needs
on Linux. Keep checking for libtool to be compatible with OSX, where
the opposite is true.