### PR TITLE
Problem: CI may fail due to timeout. Fixes #58

### DIFF
--- a/tests/test_connect_delay_tipc.cpp
+++ b/tests/test_connect_delay_tipc.cpp
@@ -85,7 +85,7 @@ int main (void)
 
     // We now consume from the connected pipe
     // - we should see just 5
-    int timeout = 100;
+    int timeout = 250;
     rc = zmq_setsockopt (to, ZMQ_RCVTIMEO, &timeout, sizeof (int));
     assert (rc == 0);
 

--- a/tests/test_filter_ipc.cpp
+++ b/tests/test_filter_ipc.cpp
@@ -47,7 +47,7 @@ static void bounce_fail (void *server, void *client)
     assert (rc == 32);
 
     //  Receive message at server side (should not succeed)
-    int timeout = 150;
+    int timeout = 250;
     rc = zmq_setsockopt (server, ZMQ_RCVTIMEO, &timeout, sizeof (int));
     assert (rc == 0);
     rc = zmq_recv (server, buffer, 32, 0);
@@ -87,7 +87,7 @@ static void run_test (int opt, T optval, int expected_error, int bounce_test)
     assert (sc);
 
     // If a test fails, don't hang for too long
-    int timeout = 1500;
+    int timeout = 2500;
     rc = zmq_setsockopt (sb, ZMQ_RCVTIMEO, &timeout, sizeof (int));
     assert (rc == 0);
     rc = zmq_setsockopt (sb, ZMQ_SNDTIMEO, &timeout, sizeof (int));

--- a/tests/test_immediate.cpp
+++ b/tests/test_immediate.cpp
@@ -76,7 +76,7 @@ int main (void)
 
     // We now consume from the connected pipe
     // - we should see just 5
-    int timeout = 100;
+    int timeout = 250;
     rc = zmq_setsockopt (to, ZMQ_RCVTIMEO, &timeout, sizeof (int));
     assert (rc == 0);
 

--- a/tests/test_req_relaxed.cpp
+++ b/tests/test_req_relaxed.cpp
@@ -54,7 +54,7 @@ int main (void)
         rep [peer] = zmq_socket (ctx, ZMQ_REP);
         assert (rep [peer]);
 
-        int timeout = 100;
+        int timeout = 250;
         rc = zmq_setsockopt (rep [peer], ZMQ_RCVTIMEO, &timeout, sizeof (int));
         assert (rc == 0);
 

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -254,7 +254,7 @@ int main (void)
     send (s, "\x01\x00", 2, 0);
     // send sneaky message that shouldn't be received
     send (s, "\x08\x00sneaky\0", 9, 0);
-    int timeout = 150;
+    int timeout = 250;
     zmq_setsockopt (server, ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
     char *buf = s_recv (server);
     if (buf != NULL) {

--- a/tests/test_security_null.cpp
+++ b/tests/test_security_null.cpp
@@ -167,7 +167,7 @@ int main (void)
     send (s, "\x01\x00", 2, 0);
     // send sneaky message that shouldn't be received
     send (s, "\x08\x00sneaky\0", 9, 0);
-    int timeout = 150;
+    int timeout = 250;
     zmq_setsockopt (server, ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
     char *buf = s_recv (server);
     if (buf != NULL) {

--- a/tests/test_security_plain.cpp
+++ b/tests/test_security_plain.cpp
@@ -173,7 +173,7 @@ int main (void)
     send (s, "\x01\x00", 2, 0);
     // send sneaky message that shouldn't be received
     send (s, "\x08\x00sneaky\0", 9, 0);
-    int timeout = 150;
+    int timeout = 250;
     zmq_setsockopt (server, ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
     char *buf = s_recv (server);
     if (buf != NULL) {

--- a/tests/test_spec_dealer.cpp
+++ b/tests/test_spec_dealer.cpp
@@ -46,7 +46,7 @@ void test_round_robin_out (void *ctx)
         rep [peer] = zmq_socket (ctx, ZMQ_REP);
         assert (rep [peer]);
 
-        int timeout = 100;
+        int timeout = 250;
         rc = zmq_setsockopt (rep [peer], ZMQ_RCVTIMEO, &timeout, sizeof (int));
         assert (rc == 0);
 
@@ -87,7 +87,7 @@ void test_fair_queue_in (void *ctx)
     void *receiver = zmq_socket (ctx, ZMQ_DEALER);
     assert (receiver);
 
-    int timeout = 100;
+    int timeout = 250;
     int rc = zmq_setsockopt (receiver, ZMQ_RCVTIMEO, &timeout, sizeof (int));
     assert (rc == 0);
 
@@ -210,7 +210,7 @@ void test_block_on_send_no_peers (void *ctx)
     void *sc = zmq_socket (ctx, ZMQ_DEALER);
     assert (sc);
 
-    int timeout = 100;
+    int timeout = 250;
     int rc = zmq_setsockopt (sc, ZMQ_SNDTIMEO, &timeout, sizeof (timeout));
     assert (rc == 0);
 

--- a/tests/test_spec_pushpull.cpp
+++ b/tests/test_spec_pushpull.cpp
@@ -46,7 +46,7 @@ void test_push_round_robin_out (void *ctx)
         pulls [peer] = zmq_socket (ctx, ZMQ_PULL);
         assert (pulls [peer]);
 
-        int timeout = 100;
+        int timeout = 250;
         rc = zmq_setsockopt (pulls [peer], ZMQ_RCVTIMEO, &timeout, sizeof (int));
         assert (rc == 0);
 
@@ -165,7 +165,7 @@ void test_push_block_on_send_no_peers (void *ctx)
     void *sc = zmq_socket (ctx, ZMQ_PUSH);
     assert (sc);
 
-    int timeout = 100;
+    int timeout = 250;
     int rc = zmq_setsockopt (sc, ZMQ_SNDTIMEO, &timeout, sizeof (timeout));
     assert (rc == 0);
 

--- a/tests/test_spec_rep.cpp
+++ b/tests/test_spec_rep.cpp
@@ -37,7 +37,7 @@ void test_fair_queue_in (void *ctx)
     void *rep = zmq_socket (ctx, ZMQ_REP);
     assert (rep);
 
-    int timeout = 100;
+    int timeout = 250;
     int rc = zmq_setsockopt (rep, ZMQ_RCVTIMEO, &timeout, sizeof (int));
     assert (rc == 0);
 

--- a/tests/test_spec_req.cpp
+++ b/tests/test_spec_req.cpp
@@ -46,7 +46,7 @@ void test_round_robin_out (void *ctx)
         rep [peer] = zmq_socket (ctx, ZMQ_REP);
         assert (rep [peer]);
 
-        int timeout = 100;
+        int timeout = 250;
         rc = zmq_setsockopt (rep [peer], ZMQ_RCVTIMEO, &timeout, sizeof (int));
         assert (rc == 0);
 
@@ -93,7 +93,7 @@ void test_req_only_listens_to_current_peer (void *ctx)
         router [i] = zmq_socket (ctx, ZMQ_ROUTER);
         assert (router [i]);
 
-        int timeout = 100;
+        int timeout = 250;
         rc = zmq_setsockopt (router [i], ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
         assert (rc == 0);
 
@@ -205,7 +205,7 @@ void test_block_on_send_no_peers (void *ctx)
     void *sc = zmq_socket (ctx, ZMQ_REQ);
     assert (sc);
 
-    int timeout = 100;
+    int timeout = 250;
     int rc = zmq_setsockopt (sc, ZMQ_SNDTIMEO, &timeout, sizeof (timeout));
     assert (rc == 0);
 

--- a/tests/test_spec_router.cpp
+++ b/tests/test_spec_router.cpp
@@ -37,7 +37,7 @@ void test_fair_queue_in (void *ctx)
     void *receiver = zmq_socket (ctx, ZMQ_ROUTER);
     assert (receiver);
 
-    int timeout = 100;
+    int timeout = 250;
     int rc = zmq_setsockopt (receiver, ZMQ_RCVTIMEO, &timeout, sizeof (int));
     assert (rc == 0);
 

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -122,7 +122,7 @@ expect_bounce_fail (void *server, void *client)
 {
     const char *content = "12345678ABCDEFGH12345678abcdefgh";
     char buffer [32];
-    int timeout = 150;
+    int timeout = 250;
 
     //  Send message from client to server
     int rc = zmq_setsockopt (client, ZMQ_SNDTIMEO, &timeout, sizeof (int));


### PR DESCRIPTION
Solution: cherry-pick Pieter Hintjens commit a7a512ab from libzmq
repository to increase test timeouts to 250 msec.

Cherry-picked from: https://github.com/zeromq/libzmq/commit/a7a512ab