### PR TITLE
Enable container-based build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,23 @@ os:
 - linux
 - osx
 
+sudo: false
+
+env:
+ global:
+  - BUILD_PREFIX=$PWD/tmp
+  - CFLAGS=-I${BUILD_PREFIX}/include
+  - CPPFLAGS=-I${BUILD_PREFIX}/include
+  - CXXFLAGS=-I${BUILD_PREFIX}/include
+  - LDFLAGS=-L${BUILD_PREFIX}/lib
+  - PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig
+
 #   Build required projects first
 before_script:
-
+- mkdir tmp
 #   libsodium
 - git clone git://github.com/jedisct1/libsodium.git
-- ( cd libsodium; ./autogen.sh; ./configure; make check; sudo make install;
-      if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi )
+- ( cd libsodium; ./autogen.sh; ./configure --prefix=${BUILD_PREFIX}; make check; make install )
 
 # ZMQ stress tests need more open socket (files) than the usual default
 # On OSX, it seems the way to set the max files limit is constantly changing, so
@@ -21,5 +31,5 @@ before_script:
 
 #   Build and check this project
 script:
-- ./autogen.sh && ./configure && make && make check
-- sudo make install
+- ./autogen.sh && ./configure --prefix=${BUILD_PREFIX} && make && make check
+- make install


### PR DESCRIPTION
Hello,

As discussed in https://github.com/zeromq/libzmq/pull/1529 here's a PR to switch from VM to container based Travis CI builds. Needed changes were removing "sudo" and installing in local directory rather than in the default /usr/local.