### PR TITLE
Fix CMake configuration issue with MSVC 2015.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,10 +117,10 @@ check_include_files(windows.h ZMQ_HAVE_WINDOWS)
 check_include_files(sys/uio.h ZMQ_HAVE_UIO)
 check_include_files(sys/eventfd.h ZMQ_HAVE_EVENTFD)
 
-check_library_exists(ws2_32 printf "" HAVE_WS2_32) # TODO: Why doesn't something logical like WSAStartup work?
-check_library_exists(ws2 printf "" HAVE_WS2)
-check_library_exists(rpcrt4 printf "" HAVE_RPCRT4) # UuidCreateSequential
-check_library_exists(iphlpapi printf "" HAVE_IPHLAPI) # GetAdaptersAddresses
+check_library_exists(ws2_32 WSAStartup "" HAVE_WS2_32)
+check_library_exists(ws2 WSAStartup "" HAVE_WS2)
+check_library_exists(rpcrt4 UuidCreate "" HAVE_RPCRT4)
+check_library_exists(iphlpapi GetNetworkParams "" HAVE_IPHLAPI)
 
 check_cxx_symbol_exists(SO_PEERCRED sys/socket.h ZMQ_HAVE_SO_PEERCRED)
 check_cxx_symbol_exists(LOCAL_PEERCRED sys/socket.h ZMQ_HAVE_LOCAL_PEERCRED)


### PR DESCRIPTION
Check for actual functions in ws2_32, ws2, rpcrt4, iphlpapi instead of printf.
MSVC 2015 has C runtime globally refactored. Looks like these libraries don't explicitly require msvcrt anymore, which contained printf.