### PR TITLE
Fix FindAsciiDoc module for CMake 3

### DIFF
--- a/builds/cmake/Modules/FindAsciiDoc.cmake
+++ b/builds/cmake/Modules/FindAsciiDoc.cmake
@@ -6,17 +6,20 @@
 # A2X_EXECUTABLE - the full path to a2x
 # A2X_FOUND - If false, don't attempt to use a2x.
 
+# CMP0053: Unable to refer to $ENV{PROGRAMFILES(X86)}
+set(PROGRAMFILESX86 "PROGRAMFILES(X86)")
+
 find_program(ASCIIDOC_EXECUTABLE asciidoc asciidoc.py
              PATHS "$ENV{ASCIIDOC_ROOT}"
                    "$ENV{PROGRAMW6432}/asciidoc"
                    "$ENV{PROGRAMFILES}/asciidoc"
-                   "$ENV{PROGRAMFILES(X86)}/asciidoc")
+                   "$ENV{${PROGRAMFILESX86}}/asciidoc")
 
 find_program(A2X_EXECUTABLE a2x
              PATHS "$ENV{ASCIIDOC_ROOT}"
                    "$ENV{PROGRAMW6432}/asciidoc"
                    "$ENV{PROGRAMFILES}/asciidoc"
-                   "$ENV{PROGRAMFILES(X86)}/asciidoc")
+                   "$ENV{${PROGRAMFILESX86}}/asciidoc")
 
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Fixed '(' and ')' braces usage volation according to CMake policy CMP0053 in FindAsciiDoc module.

```
CMake Warning (dev) at builds/cmake/Modules/FindAsciiDoc.cmake:9 (find_program):
  Policy CMP0053 is not set: Simplify variable reference and escape sequence
  evaluation.  Run "cmake --help-policy CMP0053" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  For input:

    '$ENV{PROGRAMFILES(X86)}/asciidoc'

  the old evaluation rules produce:

    'C:\Program Files (x86)/asciidoc'

  but the new evaluation rules produce an error:

    Syntax error in cmake code at
      C:/Projects/forks/zeromq4-1/builds/cmake/Modules/FindAsciiDoc.cmake:13
    when parsing string
      $ENV{PROGRAMFILES(X86)}/asciidoc
    Invalid character ('(') in a variable name: 'PROGRAMFILES'

  Using the old result for compatibility since the policy is not set.
Call Stack (most recent call first):
  CMakeLists.txt:276 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```