### PR TITLE
Revert "stdint.h is available in VS2008 (1500)"

### DIFF
--- a/src/stdint.hpp
+++ b/src/stdint.hpp
@@ -36,7 +36,7 @@
 
 #include <inttypes.h>
 
-#elif defined _MSC_VER && _MSC_VER < 1500
+#elif defined _MSC_VER && _MSC_VER < 1600
 
 #ifndef int8_t
 typedef __int8 int8_t;


### PR DESCRIPTION
VS2008 doesn't have a proper stdint.h

Reverts #42 
closes zeromq/libzmq#1630