### PR TITLE
Problem: return code of sodium_init() is not checked.

### DIFF
--- a/src/curve_client.cpp
+++ b/src/curve_client.cpp
@@ -48,6 +48,7 @@ zmq::curve_client_t::curve_client_t (const options_t &options_) :
     cn_peer_nonce(1),
     sync()
 {
+    int rc;
     memcpy (public_key, options_.curve_public_key, crypto_box_PUBLICKEYBYTES);
     memcpy (secret_key, options_.curve_secret_key, crypto_box_SECRETKEYBYTES);
     memcpy (server_key, options_.curve_server_key, crypto_box_PUBLICKEYBYTES);
@@ -57,12 +58,12 @@ zmq::curve_client_t::curve_client_t (const options_t &options_) :
     unsigned char tmpbytes[4];
     randombytes(tmpbytes, 4);
 #else
-    // todo check return code
-    sodium_init();
+    rc = sodium_init ();
+    zmq_assert (rc != -1);
 #endif
 
     //  Generate short-term key pair
-    const int rc = crypto_box_keypair (cn_public, cn_secret);
+    rc = crypto_box_keypair (cn_public, cn_secret);
     zmq_assert (rc == 0);
 }
 

--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -52,6 +52,7 @@ zmq::curve_server_t::curve_server_t (session_base_t *session_,
     cn_peer_nonce(1),
     sync()
 {
+    int rc;
     //  Fetch our secret key from socket options
     memcpy (secret_key, options_.curve_secret_key, crypto_box_SECRETKEYBYTES);
     scoped_lock_t lock (sync);
@@ -60,12 +61,12 @@ zmq::curve_server_t::curve_server_t (session_base_t *session_,
     unsigned char tmpbytes[4];
     randombytes(tmpbytes, 4);
 #else
-    // todo check return code
-    sodium_init();
+    rc = sodium_init ();
+    zmq_assert (rc != -1);
 #endif
 
     //  Generate short-term key pair
-    const int rc = crypto_box_keypair (cn_public, cn_secret);
+    rc = crypto_box_keypair (cn_public, cn_secret);
     zmq_assert (rc == 0);
 }
 


### PR DESCRIPTION
There are two todo comments in curve_client.cpp and curve_server.cpp that suggest
checking the return code of sodium_init() call. sodium_init() returns -1 on error,
0 on success and 1 if it has been called before and is already initalized:
https://github.com/jedisct1/libsodium/blob/master/src/libsodium/sodium/core.c