### PR TITLE
don't include stdint.h on msc < 1600

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -74,6 +74,16 @@ extern "C" {
 #define ZMQ_DEFINED_STDINT 1
 #if defined ZMQ_HAVE_SOLARIS || defined ZMQ_HAVE_OPENVMS
 #   include <inttypes.h>
+#elif defined _MSC_VER && _MSC_VER < 1600
+#   ifndef int32_t
+        typedef __int32 int32_t;
+#   endif
+#   ifndef uint16_t
+        typedef unsigned __int16 uint16_t;
+#   endif
+#   ifndef uint8_t
+        typedef unsigned __int8 uint8_t;
+#   endif
 #else
 #   include <stdint.h>
 #endif


### PR DESCRIPTION
where stdint.h is unavailable

(see stdint.hpp for the same check)

fixes regression in #35