### PR TITLE
update minimum _WIN32_WINNT version to 0x0600 for 4.1.4 onwards

### DIFF
--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -37,18 +37,15 @@
 #define NOMINMAX          // Macros min(a,b) and max(a,b)
 #endif
 
-//  Set target version to Windows Server 2003, Windows XP/SP1 or higher.
+//  Set target version to Windows Vista or higher, required by if_nametoindex
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0501
+#define _WIN32_WINNT 0x0600
 #endif
 
-#ifdef __MINGW32__
-//  Require Windows XP or higher with MinGW for getaddrinfo().
-#if(_WIN32_WINNT >= 0x0501)
+#if(_WIN32_WINNT >= 0x0600)
 #else
 #undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0501
-#endif
+#define _WIN32_WINNT 0x0600
 #endif
 
 #include <winsock2.h>


### PR DESCRIPTION
if_nametoindex requires minimum windows version vista, which is 0x0600.

additionally, mingw defines _WIN32_WINNT as 0x0501, and the preprocessor will decide that 0x0501 is acceptable per the code, but will fail compilation.

unless there is a way to disable the newer client-server model (i believe this is what uses if_nametoindex) then the minimum version for 4.1.4 and onwards needs to be bumped to _WIN32_WINNT >= 0x0600