### PR TITLE
Fix build errors for mingw

### DIFF
--- a/src/err.cpp
+++ b/src/err.cpp
@@ -28,7 +28,6 @@
 */
 
 #include "err.hpp"
-#include "platform.hpp"
 
 const char *zmq::errno_to_string (int errno_)
 {

--- a/src/err.hpp
+++ b/src/err.hpp
@@ -41,16 +41,17 @@
 #include <stdio.h>
 
 #include "platform.hpp"
-#include "likely.hpp"
-
-//  0MQ-specific error codes are defined in zmq.h
-#include "../include/zmq.h"
 
 #ifdef ZMQ_HAVE_WINDOWS
 #include "windows.hpp"
 #else
 #include <netdb.h>
 #endif
+
+#include "likely.hpp"
+
+//  0MQ-specific error codes are defined in zmq.h
+#include "../include/zmq.h"
 
 // EPROTO is not used by OpenBSD and maybe other platforms.
 #ifndef EPROTO

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -27,6 +27,12 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "platform.hpp"
+
+#ifdef ZMQ_HAVE_WINDOWS
+#include "windows.hpp"
+#endif
+
 #include "msg.hpp"
 #include "../include/zmq.h"
 

--- a/src/poller.hpp
+++ b/src/poller.hpp
@@ -38,6 +38,10 @@
 #error More than one of the ZMQ_USE_* macros defined
 #endif
 
+#ifdef ZMQ_HAVE_WINDOWS
+#include "windows.hpp"
+#endif
+
 #if defined ZMQ_USE_KQUEUE
 #include "kqueue.hpp"
 #elif defined ZMQ_USE_EPOLL

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -39,13 +39,13 @@
 
 //  Set target version to Windows Vista or higher, required by if_nametoindex
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600
+#define _WIN32_WINNT 0x0501
 #endif
 
-#if(_WIN32_WINNT >= 0x0600)
+#if(_WIN32_WINNT >= 0x0501)
 #else
 #undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600
+#define _WIN32_WINNT 0x0501
 #endif
 
 #include <winsock2.h>

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -51,7 +51,6 @@
 #include <winsock2.h>
 #include <windows.h>
 #include <mswsock.h>
-#include <iphlpapi.h>
 
 #if !defined __MINGW32__
 #include <Mstcpip.h>

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -51,6 +51,7 @@
 #include <winsock2.h>
 #include <windows.h>
 #include <mswsock.h>
+#include <lphlpapi.h>
 
 #if !defined __MINGW32__
 #include <Mstcpip.h>

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -51,7 +51,7 @@
 #include <winsock2.h>
 #include <windows.h>
 #include <mswsock.h>
-#include <lphlpapi.h>
+#include <iphlpapi.h>
 
 #if !defined __MINGW32__
 #include <Mstcpip.h>

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -37,7 +37,6 @@
 #define NOMINMAX          // Macros min(a,b) and max(a,b)
 #endif
 
-//  Set target version to Windows Vista or higher, required by if_nametoindex
 #ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0501
 #endif

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -245,7 +245,11 @@ int main (void)
 
     ip4addr.sin_family = AF_INET;
     ip4addr.sin_port = htons (9998);
-    inet_pton (AF_INET, "127.0.0.1", &ip4addr.sin_addr);
+#if (ZMQ_HAVE_WINDOWS and _WIN32_WINNT < 0x0600)
+    ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
+#else
+    inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);
+#endif
 
     s = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
     rc = connect (s, (struct sockaddr*) &ip4addr, sizeof (ip4addr));

--- a/tests/test_security_null.cpp
+++ b/tests/test_security_null.cpp
@@ -158,8 +158,11 @@ int main (void)
 
     ip4addr.sin_family = AF_INET;
     ip4addr.sin_port = htons(9003);
+#if (ZMQ_HAVE_WINDOWS and _WIN32_WINNT < 0x0600)
+    ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
+#else
     inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);
-
+#endif
     s = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
     rc = connect (s, (struct sockaddr*) &ip4addr, sizeof ip4addr);
     assert (rc > -1);

--- a/tests/test_security_plain.cpp
+++ b/tests/test_security_plain.cpp
@@ -164,7 +164,11 @@ int main (void)
 
     ip4addr.sin_family = AF_INET;
     ip4addr.sin_port = htons (9998);
-    inet_pton (AF_INET, "127.0.0.1", &ip4addr.sin_addr);
+#if (ZMQ_HAVE_WINDOWS and _WIN32_WINNT < 0x0600)
+    ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
+#else
+    inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);
+#endif
 
     s = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
     rc = connect (s, (struct sockaddr*) &ip4addr, sizeof (ip4addr));


### PR DESCRIPTION
mingw builds were failing due to errors with windows functions. added minimum appropriate includes with include guards to allow builds to pass.

added check to security tests to enable default mingw _Win32_WINNT value compilation