### PR TITLE
Revert "update minimum _WIN32_WINNT version to 0x0600 for 4.1.4 onwards"

### DIFF
--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -37,15 +37,18 @@
 #define NOMINMAX          // Macros min(a,b) and max(a,b)
 #endif
 
-//  Set target version to Windows Vista or higher, required by if_nametoindex
+//  Set target version to Windows Server 2003, Windows XP/SP1 or higher.
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600
+#define _WIN32_WINNT 0x0501
 #endif
 
-#if(_WIN32_WINNT >= 0x0600)
+#ifdef __MINGW32__
+//  Require Windows XP or higher with MinGW for getaddrinfo().
+#if(_WIN32_WINNT >= 0x0501)
 #else
 #undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600
+#define _WIN32_WINNT 0x0501
+#endif
 #endif
 
 #include <winsock2.h>


### PR DESCRIPTION
Reverts zeromq/zeromq4-1#95

That PR was meant to fix the use of `if_nametoindex`, which has been removed specifically so this change would not be necessary.