### PR TITLE
Problem: can't be sure crypto_box always returns 0

### DIFF
--- a/src/curve_client.cpp
+++ b/src/curve_client.cpp
@@ -198,7 +198,6 @@ int zmq::curve_client_t::decode (msg_t *msg_)
     }
     cn_peer_nonce = nonce;
 
-
     const size_t clen = crypto_box_BOXZEROBYTES + (msg_->size () - 16);
 
     uint8_t *message_plaintext = static_cast <uint8_t *> (malloc (clen));
@@ -264,7 +263,8 @@ int zmq::curve_client_t::produce_hello (msg_t *msg_)
     int rc = crypto_box (hello_box, hello_plaintext,
                          sizeof hello_plaintext,
                          hello_nonce, server_key, cn_secret);
-    zmq_assert (rc == 0);
+    if (rc == -1)
+        return -1;
 
     rc = msg_->init_size (200);
     errno_assert (rc == 0);
@@ -343,7 +343,8 @@ int zmq::curve_client_t::produce_initiate (msg_t *msg_)
     int rc = crypto_box (vouch_box, vouch_plaintext,
                          sizeof vouch_plaintext,
                          vouch_nonce, cn_server, secret_key);
-    zmq_assert (rc == 0);
+    if (rc == -1)
+        return -1;
 
     //  Assume here that metadata is limited to 256 bytes
     uint8_t initiate_nonce [crypto_box_NONCEBYTES];
@@ -379,7 +380,8 @@ int zmq::curve_client_t::produce_initiate (msg_t *msg_)
 
     rc = crypto_box (initiate_box, initiate_plaintext,
                      mlen, initiate_nonce, cn_server, cn_secret);
-    zmq_assert (rc == 0);
+    if (rc == -1)
+        return -1;
 
     rc = msg_->init_size (113 + mlen - crypto_box_BOXZEROBYTES);
     errno_assert (rc == 0);

--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -376,7 +376,8 @@ int zmq::curve_server_t::produce_welcome (msg_t *msg_)
     rc = crypto_box (welcome_ciphertext, welcome_plaintext,
                      sizeof welcome_plaintext,
                      welcome_nonce, cn_client, secret_key);
-    zmq_assert (rc == 0);
+    if (rc == -1)
+        return -1;
 
     rc = msg_->init_size (168);
     errno_assert (rc == 0);

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -156,7 +156,7 @@ int main (void)
 
     //  Check CURVE security with a garbage server key
     //  This will be caught by the curve_server class, not passed to ZAP
-    char garbage_key [] = "0000111122223333444455556666777788889999";
+    char garbage_key [] = "0000000000000000000000000000000000000000";
     client = zmq_socket (ctx, ZMQ_DEALER);
     assert (client);
     rc = zmq_setsockopt (client, ZMQ_CURVE_SERVERKEY, garbage_key, 41);


### PR DESCRIPTION
Libsodium has started returning -1 in some cases.

Solution: allow and handle error returns from these calls.

Fixes #1831