### PR TITLE
fix: sockets are not signed int on Windows

### DIFF
--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -237,7 +237,7 @@ int zmq::tcp_connecter_t::open ()
     s = open_socket (tcp_addr->family (), SOCK_STREAM, IPPROTO_TCP);
 
     //  IPv6 address family not supported, try automatic downgrade to IPv4.
-    if (s == -1 && tcp_addr->family () == AF_INET6
+    if (s == zmq::retired_fd && tcp_addr->family () == AF_INET6
     && errno == EAFNOSUPPORT
     && options.ipv6) {
         rc = addr->resolved.tcp_addr->resolve (

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -169,7 +169,7 @@ int zmq::tcp_listener_t::set_address (const char *addr_)
     s = open_socket (address.family (), SOCK_STREAM, IPPROTO_TCP);
 
     //  IPv6 address family not supported, try automatic downgrade to IPv4.
-    if (s == -1 && address.family () == AF_INET6
+    if (s == zmq::retired_fd && address.family () == AF_INET6
     && errno == EAFNOSUPPORT
     && options.ipv6) {
         rc = address.resolve (addr_, true, false);


### PR DESCRIPTION
backported from libzmq