### PR TITLE
Backport fix for issue 1542 to zmq 4.1.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,7 +356,9 @@ endif()
 #-----------------------------------------------------------------------------
 # default to Release build
 
-if(NOT CMAKE_BUILD_TYPE)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  # CMAKE_BUILD_TYPE is not used for multi-configuration generators like Visual Studio/XCode
+  # which instead use CMAKE_CONFIGURATION_TYPES
   set(CMAKE_BUILD_TYPE Release CACHE STRING
       "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
       FORCE)
@@ -465,7 +467,8 @@ set(cxx-sources
         xpub.cpp
         xsub.cpp
         zmq.cpp
-        zmq_utils.cpp)
+        zmq_utils.cpp
+        config.hpp)
 
 set(rc-sources version.rc)
 

--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,8 @@
 
 * Fixed #1952 - CMake scripts not part of release tarballs
 
+* Fixed #1542 - Fix a crash on Windows when port 5905 is in use.
+
 
 0MQ version 4.1.4 stable, released on 2015/12/18
 ================================================

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -89,7 +89,11 @@ namespace zmq
 
         //  On some OSes the signaler has to be emulated using a TCP
         //  connection. In such cases following port is used.
-        signaler_port = 5905
+        //  If 0, it lets the OS choose a free port without requiring use of a 
+        //  global mutex. The original implementation of a Windows signaler 
+        //  socket used port 5905 instead of letting the OS choose a free port.
+        //  https://github.com/zeromq/libzmq/issues/1542
+        signaler_port = 0
     };
 
 }


### PR DESCRIPTION
This is the fix for [issue 1542](https://github.com/zeromq/libzmq/issues/1542), originally [PR 1543](https://github.com/zeromq/libzmq/pull/1543). It fixes a crash on Windows when port 5905 is already used by another process. Instead, let the OS choose a port which also makes the need for the event or mutex obsolete.