### PR TITLE
allow to build sparc (v8,leon)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -291,7 +291,7 @@ fi
 
 # CPU-specific optimizations
 case "${host_cpu}" in
-    *sparc*)
+    *sparc64*)
         AC_LANG_PUSH([C++])
         LIBZMQ_CHECK_LANG_FLAG_PREPEND([-mcpu=v9])
         AC_LANG_POP([C++])


### PR DESCRIPTION
Only set sparcv9 optimization for sparc64 systems.
This allows to run for example application using zeromq
on sparc32 systems.

Signed-off-by: Waldemar Brodkorb <wbx@uclibc-ng.org>