### PR TITLE
Fix alignment problem with zmq_msg_t

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -205,7 +205,10 @@ ZMQ_EXPORT int zmq_ctx_destroy (void *context);
 /*  0MQ message definition.                                                   */
 /******************************************************************************/
 
-typedef struct zmq_msg_t {unsigned char _ [64];} zmq_msg_t;
+/* union here ensures correct alignment on architectures that require it, e.g.
+ * SPARC and ARM
+ */
+typedef union zmq_msg_t { unsigned char _ [64]; void *p; } zmq_msg_t;
 
 typedef void (zmq_free_fn) (void *data, void *hint);
 


### PR DESCRIPTION
Problem occurs on SPARC and ARM CPUs. This commit is a backport of
https://github.com/zeromq/libzmq/commit/d9fb1d36ff2008966af538f722a1f4ab158dbf64 (from
libzmq), first reported in https://github.com/zeromq/libzmq/issues/1325.