### PR TITLE
Problem: testutil.hpp fails to build on Windows XP

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@
 
 * Fixed #2051 - getifaddrs can fail with ECONNREFUSED
 
+* Fixed #2091 - testutil.hpp fails to build on Windows XP
+
 
 0MQ version 4.1.5 stable, released on 2016/06/17
 ================================================

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -308,6 +308,9 @@ void msleep (int milliseconds)
 int
 is_ipv6_available(void)
 {
+#if defined (ZMQ_HAVE_WINDOWS) && (_WIN32_WINNT < 0x0600)
+    return 0;
+#else
     int rc, ipv6 = 1;
     struct sockaddr_in6 test_addr;
 
@@ -350,6 +353,7 @@ is_ipv6_available(void)
 #endif
 
     return ipv6;
+#endif // _WIN32_WINNT < 0x0600
 }
 
 #endif


### PR DESCRIPTION
Solution: backport https://github.com/zeromq/libzmq/pull/2092 and update NEWS