### PR TITLE
Support cross compile with MinGW on Linux

### DIFF
--- a/tweetnacl/contrib/randombytes/winrandom.c
+++ b/tweetnacl/contrib/randombytes/winrandom.c
@@ -1,5 +1,5 @@
 #include <windows.h>
-#include <WinCrypt.h>
+#include <wincrypt.h>
 
 #define NCP ((HCRYPTPROV) 0)
 


### PR DESCRIPTION
Linux uses case sensitive file system. So we can't find "wincrypt.h" by
"WinCrypt.h".