### PR TITLE
Problem: zmq_connect with IPv6 "source:port;dest:port" format is broken

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@
 
 * Fixed #2096 - add tests/CMakeLists.in and version.rc.in to dist tar
 
+* Fixed #2107 - zmq_connect with IPv6 "source:port;dest:port" broken
+
 
 0MQ version 4.1.5 stable, released on 2016/06/17
 ================================================

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -610,7 +610,7 @@ int zmq::socket_base_t::connect (const char *addr_)
             while (isalnum  (*check)
                 || isxdigit (*check)
                 || *check == '.' || *check == '-' || *check == ':'|| *check == ';'
-                || *check == ']')
+                || *check == '[' || *check == ']')
                 check++;
         }
         //  Assume the worst, now look for success

--- a/tests/test_reqrep_tcp.cpp
+++ b/tests/test_reqrep_tcp.cpp
@@ -29,9 +29,8 @@
 
 #include "testutil.hpp"
 
-int main (void)
+void test_single_connect_ipv4 (void)
 {
-    setup_test_environment();
     void *ctx = zmq_ctx_new ();
     assert (ctx);
 
@@ -55,6 +54,13 @@ int main (void)
 
     rc = zmq_ctx_term (ctx);
     assert (rc == 0);
+}
+
+int main (void)
+{
+    setup_test_environment ();
+
+    test_single_connect_ipv4 ();
 
     return 0 ;
 }

--- a/tests/test_reqrep_tcp.cpp
+++ b/tests/test_reqrep_tcp.cpp
@@ -88,7 +88,7 @@ void test_multi_connect_ipv4 (void)
     assert (rc == 0);
     rc = zmq_connect (sc, "tcp://127.0.0.1:5561");
     assert (rc == 0);
-    rc = zmq_connect (sc, "tcp://127.0.0.1:5562");
+    rc = zmq_connect (sc, "tcp://127.0.0.1:5564;127.0.0.1:5562");
     assert (rc == 0);
 
     bounce (sb0, sc);
@@ -101,7 +101,7 @@ void test_multi_connect_ipv4 (void)
 
     rc = zmq_disconnect (sc, "tcp://127.0.0.1:5560");
     assert (rc == 0);
-    rc = zmq_disconnect (sc, "tcp://127.0.0.1:5562");
+    rc = zmq_disconnect (sc, "tcp://127.0.0.1:5564;127.0.0.1:5562");
     assert (rc == 0);
     rc = zmq_disconnect (sc, "tcp://127.0.0.1:5561");
     assert (rc == 0);
@@ -214,7 +214,7 @@ void test_multi_connect_ipv6 (void)
     assert (rc == 0);
     rc = zmq_connect (sc, "tcp://[::1]:5561");
     assert (rc == 0);
-    rc = zmq_connect (sc, "tcp://[::1]:5562");
+    rc = zmq_connect (sc, "tcp://[::1]:5564;[::1]:5562");
     assert (rc == 0);
 
     bounce (sb0, sc);
@@ -227,7 +227,7 @@ void test_multi_connect_ipv6 (void)
 
     rc = zmq_disconnect (sc, "tcp://[::1]:5560");
     assert (rc == 0);
-    rc = zmq_disconnect (sc, "tcp://[::1]:5562");
+    rc = zmq_disconnect (sc, "tcp://[::1]:5564;[::1]:5562");
     assert (rc == 0);
     rc = zmq_disconnect (sc, "tcp://[::1]:5561");
     assert (rc == 0);

--- a/tests/test_reqrep_tcp.cpp
+++ b/tests/test_reqrep_tcp.cpp
@@ -46,6 +46,12 @@ void test_single_connect_ipv4 (void)
 
     bounce (sb, sc);
 
+    rc = zmq_disconnect (sc, "tcp://127.0.0.1:5560");
+    assert (rc == 0);
+
+    rc = zmq_unbind (sb, "tcp://127.0.0.1:5560");
+    assert (rc == 0);
+
     rc = zmq_close (sc);
     assert (rc == 0);
 

--- a/tests/test_reqrep_tcp.cpp
+++ b/tests/test_reqrep_tcp.cpp
@@ -62,11 +62,82 @@ void test_single_connect_ipv4 (void)
     assert (rc == 0);
 }
 
+void test_multi_connect_ipv4 (void)
+{
+    void *ctx = zmq_ctx_new ();
+    assert (ctx);
+
+    void *sb0 = zmq_socket (ctx, ZMQ_REP);
+    assert (sb0);
+    int rc = zmq_bind (sb0, "tcp://127.0.0.1:5560");
+    assert (rc == 0);
+
+    void *sb1 = zmq_socket (ctx, ZMQ_REP);
+    assert (sb1);
+    rc = zmq_bind (sb1, "tcp://127.0.0.1:5561");
+    assert (rc == 0);
+
+    void *sb2 = zmq_socket (ctx, ZMQ_REP);
+    assert (sb2);
+    rc = zmq_bind (sb2, "tcp://127.0.0.1:5562");
+    assert (rc == 0);
+
+    void *sc = zmq_socket (ctx, ZMQ_REQ);
+    assert (sc);
+    rc = zmq_connect (sc, "tcp://127.0.0.1:5560");
+    assert (rc == 0);
+    rc = zmq_connect (sc, "tcp://127.0.0.1:5561");
+    assert (rc == 0);
+    rc = zmq_connect (sc, "tcp://127.0.0.1:5562");
+    assert (rc == 0);
+
+    bounce (sb0, sc);
+    bounce (sb1, sc);
+    bounce (sb2, sc);
+    bounce (sb0, sc);
+    bounce (sb1, sc);
+    bounce (sb2, sc);
+    bounce (sb0, sc);
+
+    rc = zmq_disconnect (sc, "tcp://127.0.0.1:5560");
+    assert (rc == 0);
+    rc = zmq_disconnect (sc, "tcp://127.0.0.1:5562");
+    assert (rc == 0);
+    rc = zmq_disconnect (sc, "tcp://127.0.0.1:5561");
+    assert (rc == 0);
+
+    rc = zmq_unbind (sb0, "tcp://127.0.0.1:5560");
+    assert (rc == 0);
+
+    rc = zmq_unbind (sb1, "tcp://127.0.0.1:5561");
+    assert (rc == 0);
+
+    rc = zmq_unbind (sb2, "tcp://127.0.0.1:5562");
+    assert (rc == 0);
+
+    rc = zmq_close (sc);
+    assert (rc == 0);
+
+    rc = zmq_close (sb0);
+    assert (rc == 0);
+
+    rc = zmq_close (sb1);
+    assert (rc == 0);
+
+    rc = zmq_close (sb2);
+    assert (rc == 0);
+
+    rc = zmq_ctx_term (ctx);
+    assert (rc == 0);
+}
+
 int main (void)
 {
     setup_test_environment ();
 
     test_single_connect_ipv4 ();
+
+    test_multi_connect_ipv4 ();
 
     return 0 ;
 }

--- a/tests/test_reqrep_tcp.cpp
+++ b/tests/test_reqrep_tcp.cpp
@@ -131,6 +131,132 @@ void test_multi_connect_ipv4 (void)
     assert (rc == 0);
 }
 
+void test_single_connect_ipv6 (void)
+{
+    void *ctx = zmq_ctx_new ();
+    assert (ctx);
+
+    if (!is_ipv6_available ()) {
+        zmq_ctx_term (ctx);
+        return;
+    }
+
+    void *sb = zmq_socket (ctx, ZMQ_REP);
+    assert (sb);
+    int ipv6 = 1;
+    int rc = zmq_setsockopt (sb, ZMQ_IPV6, &ipv6, sizeof (int));
+    assert (rc == 0);
+    rc = zmq_bind (sb, "tcp://[::1]:5560");
+    assert (rc == 0);
+
+    void *sc = zmq_socket (ctx, ZMQ_REQ);
+    assert (sc);
+    rc = zmq_setsockopt (sc, ZMQ_IPV6, &ipv6, sizeof (int));
+    assert (rc == 0);
+    rc = zmq_connect (sc, "tcp://[::1]:5560");
+    assert (rc == 0);
+
+    bounce (sb, sc);
+
+    rc = zmq_disconnect (sc, "tcp://[::1]:5560");
+    assert (rc == 0);
+
+    rc = zmq_unbind (sb, "tcp://[::1]:5560");
+    assert (rc == 0);
+
+    rc = zmq_close (sc);
+    assert (rc == 0);
+
+    rc = zmq_close (sb);
+    assert (rc == 0);
+
+    rc = zmq_ctx_term (ctx);
+    assert (rc == 0);
+}
+
+void test_multi_connect_ipv6 (void)
+{
+    void *ctx = zmq_ctx_new ();
+    assert (ctx);
+
+    if (!is_ipv6_available ()) {
+        zmq_ctx_term (ctx);
+        return;
+    }
+
+    void *sb0 = zmq_socket (ctx, ZMQ_REP);
+    assert (sb0);
+    int ipv6 = 1;
+    int rc = zmq_setsockopt (sb0, ZMQ_IPV6, &ipv6, sizeof (int));
+    assert (rc == 0);
+    rc = zmq_bind (sb0, "tcp://[::1]:5560");
+    assert (rc == 0);
+
+    void *sb1 = zmq_socket (ctx, ZMQ_REP);
+    assert (sb1);
+    rc = zmq_setsockopt (sb1, ZMQ_IPV6, &ipv6, sizeof (int));
+    assert (rc == 0);
+    rc = zmq_bind (sb1, "tcp://[::1]:5561");
+    assert (rc == 0);
+
+    void *sb2 = zmq_socket (ctx, ZMQ_REP);
+    assert (sb2);
+    rc = zmq_setsockopt (sb2, ZMQ_IPV6, &ipv6, sizeof (int));
+    assert (rc == 0);
+    rc = zmq_bind (sb2, "tcp://[::1]:5562");
+    assert (rc == 0);
+
+    void *sc = zmq_socket (ctx, ZMQ_REQ);
+    assert (sc);
+    rc = zmq_setsockopt (sc, ZMQ_IPV6, &ipv6, sizeof (int));
+    assert (rc == 0);
+    rc = zmq_connect (sc, "tcp://[::1]:5560");
+    assert (rc == 0);
+    rc = zmq_connect (sc, "tcp://[::1]:5561");
+    assert (rc == 0);
+    rc = zmq_connect (sc, "tcp://[::1]:5562");
+    assert (rc == 0);
+
+    bounce (sb0, sc);
+    bounce (sb1, sc);
+    bounce (sb2, sc);
+    bounce (sb0, sc);
+    bounce (sb1, sc);
+    bounce (sb2, sc);
+    bounce (sb0, sc);
+
+    rc = zmq_disconnect (sc, "tcp://[::1]:5560");
+    assert (rc == 0);
+    rc = zmq_disconnect (sc, "tcp://[::1]:5562");
+    assert (rc == 0);
+    rc = zmq_disconnect (sc, "tcp://[::1]:5561");
+    assert (rc == 0);
+
+    rc = zmq_unbind (sb0, "tcp://[::1]:5560");
+    assert (rc == 0);
+
+    rc = zmq_unbind (sb1, "tcp://[::1]:5561");
+    assert (rc == 0);
+
+    rc = zmq_unbind (sb2, "tcp://[::1]:5562");
+    assert (rc == 0);
+
+    rc = zmq_close (sc);
+    assert (rc == 0);
+
+    rc = zmq_close (sb0);
+    assert (rc == 0);
+
+    rc = zmq_close (sb1);
+    assert (rc == 0);
+
+    rc = zmq_close (sb2);
+    assert (rc == 0);
+
+    rc = zmq_ctx_term (ctx);
+    assert (rc == 0);
+}
+
 int main (void)
 {
     setup_test_environment ();
@@ -138,6 +264,10 @@ int main (void)
     test_single_connect_ipv4 ();
 
     test_multi_connect_ipv4 ();
+
+    test_single_connect_ipv6 ();
+
+    test_multi_connect_ipv6 ();
 
     return 0 ;
 }


### PR DESCRIPTION
Solution: backport PR https://github.com/zeromq/libzmq/pull/2111 to fix issue https://github.com/zeromq/libzmq/issues/2107