### PR TITLE
Problem: socket_type_string off-by-one error

### DIFF
--- a/src/mechanism.cpp
+++ b/src/mechanism.cpp
@@ -75,7 +75,7 @@ const char *zmq::mechanism_t::socket_type_string (int socket_type) const
     static const char *names [] = {"PAIR", "PUB", "SUB", "REQ", "REP",
                                    "DEALER", "ROUTER", "PULL", "PUSH",
                                    "XPUB", "XSUB", "STREAM"};
-    zmq_assert (socket_type >= 0 && socket_type <= 10);
+    zmq_assert (socket_type >= 0 && socket_type <= 11);
     return names [socket_type];
 }
 


### PR DESCRIPTION
Solution: check socket type from 0 to 11 to include ZMQ_STREAM