### PR TITLE
fix bug zmq4.1.x PUB msg to ZMTP 1.0 SUB svr

### DIFF
--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -118,8 +118,6 @@ namespace zmq
 
         void mechanism_ready ();
 
-        int write_subscription_msg (msg_t *msg_);
-
         size_t add_property (unsigned char *ptr,
             const char *name, const void *value, size_t value_len);
 


### PR DESCRIPTION
This pr fix [issues#2254](https://github.com/zeromq/libzmq/issues/2254) which zmq4.x pub msg to sub server run with ZMTP 1.0 protocol, such as zmq 2.x

Same as [https://github.com/zeromq/libzmq/pull/2256](https://github.com/zeromq/libzmq/pull/2256)