### PR TITLE
Add error code EHOSTDOWN to the list of acceptable error codes.

### DIFF
--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -332,6 +332,7 @@ zmq::fd_t zmq::tcp_connecter_t::connect ()
             && err != WSAETIMEDOUT
             && err != WSAECONNABORTED
             && err != WSAEHOSTUNREACH
+            && err != WSAEHOSTDOWN
             && err != WSAENETUNREACH
             && err != WSAENETDOWN
             && err != WSAEACCES
@@ -354,6 +355,7 @@ zmq::fd_t zmq::tcp_connecter_t::connect ()
             errno == ECONNRESET ||
             errno == ETIMEDOUT ||
             errno == EHOSTUNREACH ||
+            errno == EHOSTDOWN ||
             errno == ENETUNREACH ||
             errno == ENETDOWN ||
             errno == EINVAL);


### PR DESCRIPTION
Fixes #164 (EHOSTDOWN from getsockopt must not cause assertion abort; causes SaltStack crashes)